### PR TITLE
14.0 imp queue job chained job

### DIFF
--- a/queue_job/job.py
+++ b/queue_job/job.py
@@ -542,8 +542,8 @@ class Job(object):
 
         return self.result
 
-    def enqueue_waiting(self):
-        sql = """
+    def _get_common_dependent_jobs_query(self):
+        return """
             UPDATE queue_job
             SET state = %s
             FROM (
@@ -571,7 +571,15 @@ class Job(object):
             AND %s = ALL(jobs.parent_states)
             AND state = %s;
         """
+
+    def enqueue_waiting(self):
+        sql = self._get_common_dependent_jobs_query()
         self.env.cr.execute(sql, (PENDING, self.uuid, DONE, WAIT_DEPENDENCIES))
+        self.env["queue.job"].invalidate_cache(["state"])
+
+    def cancel_dependent_jobs(self):
+        sql = self._get_common_dependent_jobs_query()
+        self.env.cr.execute(sql, (CANCELLED, self.uuid, CANCELLED, WAIT_DEPENDENCIES))
         self.env["queue.job"].invalidate_cache(["state"])
 
     def store(self):

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -308,6 +308,7 @@ class QueueJob(models.Model):
             if state == DONE:
                 job_.set_done(result=result)
                 job_.store()
+                record.env["queue.job"].flush()
                 job_.enqueue_waiting()
             elif state == PENDING:
                 job_.set_pending(result=result)

--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -316,6 +316,8 @@ class QueueJob(models.Model):
             elif state == CANCELLED:
                 job_.set_cancelled(result=result)
                 job_.store()
+                record.env["queue.job"].flush()
+                job_.cancel_dependent_jobs()
             else:
                 raise ValueError("State not supported: %s" % state)
 

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -16,6 +16,7 @@ from odoo.addons.queue_job.exception import (
     RetryableJobError,
 )
 from odoo.addons.queue_job.job import (
+    CANCELLED,
     DONE,
     ENQUEUED,
     FAILED,
@@ -548,6 +549,24 @@ class TestJobModel(JobCommonCase):
         # Check the state
         self.assertEqual(record_root.state, DONE)
         self.assertEqual(record_child.state, PENDING)
+
+    def test_button_cancel_dependencies(self):
+        job_root = Job(self.env["test.queue.job"].testing_method)
+        job_child = Job(self.env["test.queue.job"].testing_method)
+        job_child.add_depends({job_root})
+
+        DelayableGraph._ensure_same_graph_uuid([job_root, job_child])
+        job_root.store()
+        job_child.store()
+
+        self.assertEqual(job_child.state, WAIT_DEPENDENCIES)
+        record_root = job_root.db_record()
+        record_child = job_child.db_record()
+        # Trigger button cancelled
+        record_root.button_cancelled()
+        # Check the state
+        self.assertEqual(record_root.state, CANCELLED)
+        self.assertEqual(record_child.state, CANCELLED)
 
     def test_requeue(self):
         stored = self._create_job()

--- a/test_queue_job/tests/test_job.py
+++ b/test_queue_job/tests/test_job.py
@@ -531,6 +531,24 @@ class TestJobModel(JobCommonCase):
             stored.result, "Manually set to done by %s" % self.env.user.name
         )
 
+    def test_button_done_enqueue_waiting_dependencies(self):
+        job_root = Job(self.env["test.queue.job"].testing_method)
+        job_child = Job(self.env["test.queue.job"].testing_method)
+        job_child.add_depends({job_root})
+
+        DelayableGraph._ensure_same_graph_uuid([job_root, job_child])
+        job_root.store()
+        job_child.store()
+
+        self.assertEqual(job_child.state, WAIT_DEPENDENCIES)
+        record_root = job_root.db_record()
+        record_child = job_child.db_record()
+        # Trigger button done
+        record_root.button_done()
+        # Check the state
+        self.assertEqual(record_root.state, DONE)
+        self.assertEqual(record_child.state, PENDING)
+
     def test_requeue(self):
         stored = self._create_job()
         stored.write({"state": "failed"})


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Refactored job dependency handling by centralizing the common SQL query into `_get_common_dependent_jobs_query`.
- Enhanced the `enqueue_waiting` method to use the centralized query.
- Introduced `cancel_dependent_jobs` to handle the cancellation of dependent jobs when a parent job is cancelled.
- Added explicit flushes after job state changes to ensure child jobs are updated correctly.
- Added tests to verify the correct state transitions of dependent jobs when a parent job is marked as done or cancelled.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>job.py</strong><dd><code>Refactor and enhance job dependency handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

queue_job/job.py

<li>Added <code>_get_common_dependent_jobs_query</code> method to centralize SQL query.<br> <li> Modified <code>enqueue_waiting</code> to use the new query method.<br> <li> Introduced <code>cancel_dependent_jobs</code> to handle cancellation of child jobs.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/nilshamerlinck/queue/pull/1/files#diff-23034efd8360efc0b59b169eb4834058fd91f6eabf06cf8a04bac0142e3cc385">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>queue_job.py</strong><dd><code>Ensure child jobs update on state change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

queue_job/models/queue_job.py

<li>Added explicit flush after job state changes to ensure child jobs are <br>updated.<br> <li> Called <code>cancel_dependent_jobs</code> when a job is cancelled.<br>


</details>


  </td>
  <td><a href="https://github.com/nilshamerlinck/queue/pull/1/files#diff-52052ee7edd7df6a68c13f1c6f9667c1556c7c08b0a8e91de76dcd7b2d604439">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_job.py</strong><dd><code>Add tests for job dependency state transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test_queue_job/tests/test_job.py

<li>Added tests for <code>enqueue_waiting</code> and <code>cancel_dependent_jobs</code>.<br> <li> Verified state transitions for dependent jobs.<br>


</details>


  </td>
  <td><a href="https://github.com/nilshamerlinck/queue/pull/1/files#diff-5751d51ef596cd6d3ea000e07099a53ac0ff75f04b58c21716631dfed83f1331">+37/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

